### PR TITLE
Add no inject decorators rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Then to use the default rules you can add `tslint-mobx` to `extends` in your `ts
   - For example if you have `@inject('someStore')` decorator wrapping your component, but `this.props.someStore` is unused. 
 - `mobx-react-no-empty-inject`
   - Makes sure you don't have any empty injects (`@inject()`).
-  
+- `mobx-react-no-inject-decorators`
+  - Makes sure you don't have any inject decorators (`@inject()`) at all on classes.
+    
 ### Adding your own rules
 Adding your own rules is straightforward.
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "url": "https://github.com/eranshabi/tslint-mobx/issues"
   },
   "homepage": "https://github.com/eranshabi/tslint-mobx#readme",
-  "files": ["dist/src"],
+  "files": [
+    "dist/src"
+  ],
   "dependencies": {
     "tslint": "^5.9.1"
   },
@@ -34,6 +36,7 @@
       "tsx",
       "js"
     ],
+    "testURL": "http://localhost/",
     "transform": {
       "^.+\\.(ts|tsx)$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-mobx",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "tslint-mobx.json",
   "scripts": {

--- a/src/rules/mobxReactNoInjectDecoratorsRule.ts
+++ b/src/rules/mobxReactNoInjectDecoratorsRule.ts
@@ -1,0 +1,26 @@
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+import { isClassDeclaration, isClassExpression } from 'tsutils';
+
+export class Rule extends Lint.Rules.AbstractRule {
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk);
+    }
+}
+
+const walk = (ctx: Lint.WalkContext<any>): void => {
+    const { sourceFile } = ctx;
+    return ts.forEachChild(sourceFile, function cb(node: ts.Node): void {
+        if (isClassDeclaration(node) || isClassExpression(node)) {
+            if (node.decorators) {
+                node.decorators.forEach(deco => {
+                    if (deco.expression && (<any>deco.expression).expression && (<any>deco.expression).expression.escapedText === 'inject') {
+                        ctx.addFailureAtNode(node, 'inject decorators are not allowed');
+                    }
+                });
+            }
+        }
+        return ts.forEachChild(node, cb);
+    });
+};

--- a/test/mobxReactNoInjectDecoratorsRule.spec.ts
+++ b/test/mobxReactNoInjectDecoratorsRule.spec.ts
@@ -1,0 +1,53 @@
+import { lintFileString, noInjectDecoratorsConfig } from './utils';
+
+describe('mobx-react-no-inject-decorators', () => {
+    it('should fail when there is an empty inject', () => {
+        const file = `
+                @inject()
+                class A extends React.Component<AddressDetailsFormProps, AState> {
+                    constructor() {
+                        super();
+                    }
+                    
+                    public render(): ReactTypes.ReactElement<any> {
+                            console.log(this.props); 
+                    }
+                }
+                `;
+        const result = lintFileString(file, noInjectDecoratorsConfig);
+        expect(result.errorCount).toEqual(1);
+    });
+
+    it('should fail when there is a not empty inject', () => {
+        const file = `
+                @inject('store')
+                class A extends React.Component<AddressDetailsFormProps, AState> {
+                    constructor() {
+                        super();
+                    }
+                    
+                    public render(): ReactTypes.ReactElement<any> {
+                            console.log(this.props); 
+                    }
+                }
+                `;
+        const result = lintFileString(file, noInjectDecoratorsConfig);
+        expect(result.errorCount).toEqual(1);
+    });
+
+    it('should pass when there are no injects', () => {
+        const file = `
+                class A extends React.Component<AddressDetailsFormProps, AState> {
+                    constructor() {
+                        super();
+                    }
+                    
+                    public render(): ReactTypes.ReactElement<any> {
+                            console.log(this.props); 
+                    }
+                }
+                `;
+        const result = lintFileString(file, noInjectDecoratorsConfig);
+        expect(result.errorCount).toEqual(0);
+    });
+});

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,14 +1,14 @@
 import * as fs from "fs";
-import {Configuration, Linter} from "tslint";
+import { Configuration, Linter } from "tslint";
 
 export const lint = (path, fileName) => {
-    const filePath = path + fileName;
-    const fileContent = fs.readFileSync(filePath, "utf8");
-    const linter = new Linter({fix: false});
-    const configuration = Configuration.findConfiguration(`${path}tslint.json`, filePath).results;
+  const filePath = path + fileName;
+  const fileContent = fs.readFileSync(filePath, "utf8");
+  const linter = new Linter({ fix: false });
+  const configuration = Configuration.findConfiguration(`${path}tslint.json`, filePath).results;
 
-    linter.lint(filePath, fileContent, configuration);
-    return linter.getResult();
+  linter.lint(filePath, fileContent, configuration);
+  return linter.getResult();
 };
 
 export const noUnusedInjectConfig = {
@@ -29,11 +29,20 @@ export const noEmptyInjectConfig = {
   "rulesDirectory": "src/rules"
 };
 
-export const lintFileString = (file, config) => {
-    const linter = new Linter({fix: false});
-    const configuration = Configuration.parseConfigFile(config);
+export const noInjectDecoratorsConfig = {
+  "defaultSeverity": "error",
+  "jsRules": {},
+  "rules": {
+    "mobx-react-no-inject-decorators": true
+  },
+  "rulesDirectory": "src/rules"
+};
 
-    linter.lint('', file, configuration);
-    return linter.getResult();
+export const lintFileString = (file, config) => {
+  const linter = new Linter({ fix: false });
+  const configuration = Configuration.parseConfigFile(config);
+
+  linter.lint('', file, configuration);
+  return linter.getResult();
 };
 


### PR DESCRIPTION
This rule checks that classes does not have the inject decorator.

In our team we do not use the inject way of doing things and we wish to disallow this.