### PR TITLE
Adding rule to prevent @action use on async methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 package-lock.json
 .idea
+dist
+node_modules

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Then to use the default rules you can add `tslint-mobx` to `extends` in your `ts
   - Makes sure you don't have any empty injects (`@inject()`).
 - `mobx-react-no-inject-decorators`
   - Makes sure you don't have any inject decorators (`@inject()`) at all on classes.
+- `mobx-react-no-async-action`
+  - Makes sure you don't have any action decorators (`@action`) on async methods. 
     
 ### Adding your own rules
 Adding your own rules is straightforward.

--- a/src/rules/mobxReactNoAsyncActionRule.ts
+++ b/src/rules/mobxReactNoAsyncActionRule.ts
@@ -1,0 +1,51 @@
+/*"no-async-with-action": context => ({
+    Decorator: function(node) {
+      if (node.expression.name === "action") {
+        const ancestors = context.getAncestors();
+        const parent = ancestors.length > 0 && ancestors[ancestors.length - 1];
+        if (parent.type === "ClassProperty") {
+          if (parent.value && parent.value.async) {
+            context.report(node, "Async methods must use flow");
+          }
+        }
+      }
+    }
+  })
+*/
+
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+import {isMethodDeclaration, isArrowFunction, isPropertyDeclaration} from 'tsutils';
+import { hasModifier } from 'tslint';
+import { SyntaxKind } from 'typescript';
+
+export class Rule extends Lint.Rules.AbstractRule {
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithFunction(sourceFile, walk);
+    }
+}
+
+const hasActionDecorator = (node:ts.Node)=>{
+   return node.decorators && node.decorators.some(deco => {
+        return (deco.expression && (deco.expression as any).escapedText === 'action')
+    });
+}
+
+const walk = (ctx: Lint.WalkContext<any>): void => {
+    const {sourceFile} = ctx;
+    return ts.forEachChild(sourceFile,  function cb(node: ts.Node): void {
+
+        if(isMethodDeclaration(node) && hasModifier(node.modifiers, SyntaxKind.AsyncKeyword) && hasActionDecorator(node)){
+            ctx.addFailureAtNode(node, "Mobx @action can't be used on async methods");
+        }
+        else if(isPropertyDeclaration(node)  && hasActionDecorator(node)){
+            const isAsync = (node.initializer && hasModifier(node.initializer.modifiers, SyntaxKind.AsyncKeyword))
+            if(isAsync) {
+                ctx.addFailureAtNode(node, "Mobx @action can't be used on async methods");
+            }
+        }
+       
+        return ts.forEachChild(node, cb);
+    });
+};

--- a/src/rules/mobxReactNoAsyncActionRule.ts
+++ b/src/rules/mobxReactNoAsyncActionRule.ts
@@ -1,18 +1,3 @@
-/*"no-async-with-action": context => ({
-    Decorator: function(node) {
-      if (node.expression.name === "action") {
-        const ancestors = context.getAncestors();
-        const parent = ancestors.length > 0 && ancestors[ancestors.length - 1];
-        if (parent.type === "ClassProperty") {
-          if (parent.value && parent.value.async) {
-            context.report(node, "Async methods must use flow");
-          }
-        }
-      }
-    }
-  })
-*/
-
 import * as Lint from 'tslint';
 import * as ts from 'typescript';
 import {isMethodDeclaration, isArrowFunction, isPropertyDeclaration} from 'tsutils';

--- a/test/mobxReactNoAsyncAction.spec.ts
+++ b/test/mobxReactNoAsyncAction.spec.ts
@@ -1,0 +1,73 @@
+import {lint, lintFileString, noAsyncActions} from './utils';
+
+describe('mobx-react-no-async-action', () => {
+    it('should fail when there is an action decorator on an async method', () => {
+        const file = `
+                class A extends React.Component<AddressDetailsFormProps, AState> {
+                    constructor() {
+                        super();
+                    }
+                    
+                    @action
+                    public async method(){
+                        console.log("I'm an action");
+                    }
+                }
+                `;
+        const result = lintFileString(file, noAsyncActions);
+        expect(result.errorCount).toEqual(1);
+    });
+
+    it('should fail when there is an action decorator on an async ClassProperty', () => {
+        const file = `
+                class A extends React.Component<AddressDetailsFormProps, AState> {
+                    constructor() {
+                        super();
+                    }
+                    
+                    @action
+                    public method = async () => {
+                        console.log("I'm an action");
+                    }
+                }
+                `;
+        const result = lintFileString(file, noAsyncActions);
+        expect(result.errorCount).toEqual(1);
+    });
+
+    it('should pass when there is an action decorator on a non-async ClassProperty', () => {
+        const file = `
+                class A extends React.Component<AddressDetailsFormProps, AState> {
+                    constructor() {
+                        super();
+                    }
+                    
+                    @action
+                    public method = () => {
+                        console.log("I'm an action");
+                    }
+                }
+                `;
+        const result = lintFileString(file, noAsyncActions);
+        expect(result.errorCount).toEqual(0);
+    });
+
+    it('should pass when there is an action decorator on a non-async method', () => {
+        const file = `
+                class A extends React.Component<AddressDetailsFormProps, AState> {
+                    constructor() {
+                        super();
+                    }
+                    
+                    @action
+                    public action(){
+                        console.log("I'm an action");
+                    }
+                }
+                `;
+        const result = lintFileString(file, noAsyncActions);
+        expect(result.errorCount).toEqual(0);
+    });
+
+
+  });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -11,6 +11,15 @@ export const lint = (path, fileName) => {
   return linter.getResult();
 };
 
+export const noAsyncActions = {
+  "defaultSeverity": "error",
+  "jsRules": {},
+  "rules": {
+    "mobx-react-no-async-action": true
+  },
+  "rulesDirectory": "src/rules"
+};
+
 export const noUnusedInjectConfig = {
   "defaultSeverity": "error",
   "jsRules": {},


### PR DESCRIPTION
@action decorator shouldn't be used with async methods, flow should be used instead.